### PR TITLE
Fix VSIX link

### DIFF
--- a/nunit.templates/source.extension.vsixmanifest
+++ b/nunit.templates/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     <Identity Id="nunit.templates.b29e95b8-bf26-4f03-983d-f1d0f21ad6ef" Version="1.2" Language="en-US" Publisher="Rob Prouse" />
     <DisplayName>NUnit Templates for Visual Studio</DisplayName>
     <Description xml:space="preserve">Provides Visual Studio project and item templates for NUnit 3 along with code snippets.</Description>
-    <MoreInfo>https://github.com/nunit/nunit.templates</MoreInfo>
+    <MoreInfo>https://github.com/nunit/nunit-vs-templates</MoreInfo>
     <License>license.rtf</License>
     <Icon>nunit3_32x32.png</Icon>
     <PreviewImage>preview.png</PreviewImage>


### PR DESCRIPTION
Just spotted this was broken in the market place. ("8 open pull requests on the template project, really?!")

https://marketplace.visualstudio.com/items?itemName=NUnitDevelopers.NUnitTemplatesforVisualStudio

Also, do we know if VSIX v3 is a requirements for VS 15? Do we need to update?