### PR TITLE
Force save project on creation 

### DIFF
--- a/nunit.templates/nunit.templates.csproj
+++ b/nunit.templates/nunit.templates.csproj
@@ -1,8 +1,31 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.14.0.23-pre\build\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.props" Condition="Exists('..\packages\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.14.0.23-pre\build\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>14.0</OldToolsVersion>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -12,6 +35,7 @@
     <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{0660DC45-821A-4763-9818-4D6798A3A253}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <VsixType>v3</VsixType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>nunit.templates</RootNamespace>
     <AssemblyName>nunit.templates</AssemblyName>
@@ -56,10 +80,6 @@
   <ItemGroup>
     <Content Include="ItemTemplates\Test\NUnit Test Fixture\icon.png" />
     <Content Include="ItemTemplates\Test\NUnit Test Fixture\TestClass.vb" />
-    <Content Include="license.rtf">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
     <Content Include="ItemTemplates\Test\NUnit Test Fixture\Definitions\CSharp.vstemplate">
       <SubType>Designer</SubType>
     </Content>
@@ -68,7 +88,6 @@
     </Content>
     <Content Include="ItemTemplates\Test\NUnit Setup Fixture\Definitions\CSharp.vstemplate" />
     <Content Include="ItemTemplates\Test\NUnit Setup Fixture\Definitions\VB.vstemplate" />
-    <None Include="packages.config" />
     <Content Include="nunit_90.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -97,6 +116,11 @@
     <Content Include="Packages\xamarin.android.support.v7.mediarouter.23.0.1.3.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="license.rtf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <None Include="packages.config" />
     <None Include="Properties\template-builder.props">
       <SubType>Designer</SubType>
     </None>
@@ -135,7 +159,6 @@
     <Reference Include="System" />
     <Reference Include="TemplateBuilder, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\TemplateBuilder.1.1.3\lib\TemplateBuilder.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -160,9 +183,24 @@
     <Folder Include="Snippets\VisualBasic\NUnit\" />
     <Folder Include="Snippets\XML\NUnit\" />
   </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(TemplateBuilderTargets)" Condition="Exists('$(TemplateBuilderTargets)')" Label="TemplateBuilder" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.14.0.23-pre\build\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.14.0.23-pre\build\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.14.0.23-pre\build\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.14.0.23-pre\build\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.14.0.23-pre\build\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.14.0.23-pre\build\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/nunit.templates/packages.config
+++ b/nunit.templates/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.VisualStudio.Sdk.BuildTasks.14.0" version="14.0.23-pre" targetFramework="net45" developmentDependency="true" />
   <package id="TemplateBuilder" version="1.1.3" targetFramework="net45" />
 </packages>

--- a/nunit.templates/source.extension.vsixmanifest
+++ b/nunit.templates/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="nunit.templates.b29e95b8-bf26-4f03-983d-f1d0f21ad6ef" Version="1.2" Language="en-US" Publisher="Rob Prouse" />
-    <DisplayName>NUnit Templates for Visual Studio</DisplayName>
+    <DisplayName>NUnit VS Templates</DisplayName>
     <Description xml:space="preserve">Provides Visual Studio project and item templates for NUnit 3 along with code snippets.</Description>
     <MoreInfo>https://github.com/nunit/nunit-vs-templates</MoreInfo>
     <License>license.rtf</License>
@@ -13,6 +13,7 @@
   <Installation>
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[12.0,]" />
     <InstallationTarget Version="[11.0,)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[11.0,)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.0,)" />
@@ -30,4 +31,7 @@
     <Asset Type="xamarin.android.support.v7.cardview.23.0.1.3.nupkg" d:Source="File" Path="Packages\xamarin.android.support.v7.cardview.23.0.1.3.nupkg" d:VsixSubPath="Packages" />
     <Asset Type="xamarin.android.support.v7.mediarouter.23.0.1.3.nupkg" d:Source="File" Path="Packages\xamarin.android.support.v7.mediarouter.23.0.1.3.nupkg" d:VsixSubPath="Packages" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/nunit.tests.csharp/_Definitions/_project.vstemplate.xml
+++ b/nunit.tests.csharp/_Definitions/_project.vstemplate.xml
@@ -8,6 +8,7 @@
         <SortOrder>1000</SortOrder>
         <CreateNewFolder>true</CreateNewFolder>
         <ProvideDefaultName>true</ProvideDefaultName>
+        <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
         <LocationField>Enabled</LocationField>
         <EnableLocationBrowseButton>true</EnableLocationBrowseButton>
         <Icon>nunit.png</Icon>

--- a/nunit.tests.vb/_Definitions/_project.vstemplate.xml
+++ b/nunit.tests.vb/_Definitions/_project.vstemplate.xml
@@ -8,6 +8,7 @@
         <SortOrder>100</SortOrder>
         <CreateNewFolder>true</CreateNewFolder>
         <ProvideDefaultName>true</ProvideDefaultName>
+        <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
         <LocationField>Enabled</LocationField>
         <EnableLocationBrowseButton>true</EnableLocationBrowseButton>
         <Icon>nunit.png</Icon>

--- a/xamarin/nunit.tests.Droid/_Definitions/_project.vstemplate.xml
+++ b/xamarin/nunit.tests.Droid/_Definitions/_project.vstemplate.xml
@@ -9,6 +9,7 @@
         <SortOrder>100</SortOrder>
         <CreateNewFolder>true</CreateNewFolder>
         <ProvideDefaultName>true</ProvideDefaultName>
+        <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
         <LocationField>Enabled</LocationField>
         <EnableLocationBrowseButton>true</EnableLocationBrowseButton>
         <Icon>nunit.png</Icon>

--- a/xamarin/nunit.tests.Droid/nunit.tests.Droid.csproj
+++ b/xamarin/nunit.tests.Droid/nunit.tests.Droid.csproj
@@ -24,7 +24,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
-    <TargetFrameworkVersion>v5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/xamarin/nunit.tests.iOS/_Definitions/_project.vstemplate.xml
+++ b/xamarin/nunit.tests.iOS/_Definitions/_project.vstemplate.xml
@@ -8,6 +8,7 @@
         <SortOrder>200</SortOrder>
         <CreateNewFolder>true</CreateNewFolder>
         <ProvideDefaultName>true</ProvideDefaultName>
+        <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
         <LocationField>Enabled</LocationField>
         <EnableLocationBrowseButton>true</EnableLocationBrowseButton>
         <Icon>nunit.png</Icon>

--- a/xamarin/nunit.tests.uwp/_Definitions/_project.vstemplate.xml
+++ b/xamarin/nunit.tests.uwp/_Definitions/_project.vstemplate.xml
@@ -8,6 +8,7 @@
         <SortOrder>300</SortOrder>
         <CreateNewFolder>true</CreateNewFolder>
         <ProvideDefaultName>true</ProvideDefaultName>
+        <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
         <LocationField>Enabled</LocationField>
         <EnableLocationBrowseButton>true</EnableLocationBrowseButton>
         <TargetPlatformName>Windows</TargetPlatformName>


### PR DESCRIPTION
Fixes #21.

Ideally this wouldn't be necessary, but until https://github.com/NuGet/Home/issues/3843 is fixed, forcing save on creation is a workaround for the weird errors thrown by NuGet.

Note: This is branched off #31 - that should be merged first, after which this will hopefully show the correct diff!