### PR TITLE
Changed TargetFrameworkVersion to be used with template parameter

### DIFF
--- a/nunit.tests.csharp/nunit.tests.csharp.csproj
+++ b/nunit.tests.csharp/nunit.tests.csharp.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NUnit.Tests</RootNamespace>
     <AssemblyName>NUnit.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/nunit.tests.vb/nunit.tests.vb.vbproj
+++ b/nunit.tests.vb/nunit.tests.vb.vbproj
@@ -10,7 +10,7 @@
     <AssemblyName>NUnit.Tests</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
When adding a new NUnit project in Visual Studio, currently it discards user's choice of target framework version and it always uses .NET v4.5.
With this change, project applies the user's choice.