### PR TITLE
Designated projects as tests instead of class libraries

### DIFF
--- a/nunit.tests.csharp/nunit.tests.csharp.csproj
+++ b/nunit.tests.csharp/nunit.tests.csharp.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>NUnit.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+	<ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/nunit.tests.vb/nunit.tests.vb.vbproj
+++ b/nunit.tests.vb/nunit.tests.vb.vbproj
@@ -11,6 +11,7 @@
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	<ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</ProjectTypeGuids>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
The project is recognized as a test project when the respective project type GUIDs is provided.
Also, a flask icon is added to a project's symbol in Visual Studio's Solution Explorer when the project is designated as test. It is a helpful visual cue.
The GUID infos are acquired from [codeproject.com/reference/720512/list-of-visual-studio-project-type-guids](https://www.codeproject.com/reference/720512/list-of-visual-studio-project-type-guids) and VS's default test project templates.
