### PR TITLE
Support VS2019

### DIFF
--- a/nunit.templates/source.extension.vsixmanifest
+++ b/nunit.templates/source.extension.vsixmanifest
@@ -1,34 +1,34 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="nunit.templates.b29e95b8-bf26-4f03-983d-f1d0f21ad6ef" Version="1.3" Language="en-US" Publisher="Rob Prouse" />
-    <DisplayName>NUnit VS Templates</DisplayName>
-    <Description xml:space="preserve">Provides Visual Studio project and item templates for NUnit 3 along with code snippets.</Description>
-    <MoreInfo>https://github.com/nunit/nunit-vs-templates</MoreInfo>
-    <License>license.rtf</License>
-    <Icon>nunit_90.png</Icon>
-    <PreviewImage>preview.png</PreviewImage>
-    <Tags>tdd, test, NUnit, NUnit3, template, snippet</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[12.0,]" />
-    <InstallationTarget Version="[11.0,)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[11.0,)" Id="Microsoft.VisualStudio.Enterprise" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.0,)" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="Output\ItemTemplates" />
-    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="Output\ProjectTemplates" />
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="snippets.pkgdef" />
-    <Asset Type="nunit.3.6.1.nupkg" d:Source="File" Path="Packages\NUnit.3.6.1.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="pclstorage.1.0.2.nupkg" d:Source="File" Path="Packages\pclstorage.1.0.2.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="xamarin.forms.1.5.0.6447.nupkg" d:Source="File" Path="Packages\xamarin.forms.1.5.0.6447.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="xamarin.android.support.v4.22.2.1.nupkg" d:Source="File" Path="Packages\xamarin.android.support.v4.22.2.1.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="nunit.xamarin.3.6.1.nupkg" d:Source="File" Path="Packages\nunit.xamarin.3.6.1.nupkg" d:VsixSubPath="Packages" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+    <Metadata>
+        <Identity Id="nunit.templates.b29e95b8-bf26-4f03-983d-f1d0f21ad6ef" Version="1.3" Language="en-US" Publisher="Rob Prouse" />
+        <DisplayName>NUnit VS Templates</DisplayName>
+        <Description xml:space="preserve">Provides Visual Studio project and item templates for NUnit 3 along with code snippets.</Description>
+        <MoreInfo>https://github.com/nunit/nunit-vs-templates</MoreInfo>
+        <License>license.rtf</License>
+        <Icon>nunit_90.png</Icon>
+        <PreviewImage>preview.png</PreviewImage>
+        <Tags>tdd, test, NUnit, NUnit3, template, snippet</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[12.0,]" />
+        <InstallationTarget Version="[11.0,)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[11.0,)" Id="Microsoft.VisualStudio.Enterprise" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.0,)" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="Output\ItemTemplates" />
+        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="Output\ProjectTemplates" />
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="snippets.pkgdef" />
+        <Asset Type="nunit.3.6.1.nupkg" d:Source="File" Path="Packages\NUnit.3.6.1.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="pclstorage.1.0.2.nupkg" d:Source="File" Path="Packages\pclstorage.1.0.2.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="xamarin.forms.1.5.0.6447.nupkg" d:Source="File" Path="Packages\xamarin.forms.1.5.0.6447.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="xamarin.android.support.v4.22.2.1.nupkg" d:Source="File" Path="Packages\xamarin.android.support.v4.22.2.1.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="nunit.xamarin.3.6.1.nupkg" d:Source="File" Path="Packages\nunit.xamarin.3.6.1.nupkg" d:VsixSubPath="Packages" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[11.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Tried building master in VS2017 and VS2019 and the command line, but I get `The "GetDeploymentPathFromVsixManifest" task failed unexpectedly.` in `packages\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.14.0.23-pre\tools\VSSDK\Microsoft.VsSDK.targets(644,5)`. Happy to test this if anyone knows what's up.